### PR TITLE
modify metro.config.js to allow expo to build the static files and ad…

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,5 +22,6 @@
     "react": {
       "version": "detect"
     }
-  }
+  },
+  "ignorePatterns": ["dist/"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ yarn-error.*
 *.tsbuildinfo
 
 .idea
+.vercel

--- a/metro.config.js
+++ b/metro.config.js
@@ -1,5 +1,5 @@
 // metro.config.js
-const { getDefaultConfig } = require('expo/metro-config');
+const { getDefaultConfig } = require("expo/metro-config");
 
 const defaultConfig = getDefaultConfig(__dirname);
 

--- a/metro.config.js
+++ b/metro.config.js
@@ -1,11 +1,6 @@
-const { getDefaultConfig, mergeConfig } = require("@react-native/metro-config");
+// metro.config.js
+const { getDefaultConfig } = require('expo/metro-config');
 
-/**
- * Metro configuration
- * https://reactnative.dev/docs/metro
- *
- * @type {import('metro-config').MetroConfig}
- */
-const config = {};
+const defaultConfig = getDefaultConfig(__dirname);
 
-module.exports = mergeConfig(getDefaultConfig(__dirname), config);
+module.exports = defaultConfig;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "npx eslint . --fix",
     "lint:check": "npx eslint .",
     "format": "npx prettier . --write",
-    "format:check": "npx prettier . --check"
+    "format:check": "npx prettier . --check",
+    "build": "expo export"
   },
   "dependencies": {
     "@expo/metro-runtime": "~3.1.3",


### PR DESCRIPTION
…d this build command to package.json

### Summary

Adds build script to package.json
modifies metro.config.js to allow vercel to build static files from react-native files
adds vercel folder to .gitignore


### Checklist

- [ ] Tested the code as a web app :feelsgood:
- [ ] Tested the code as an android app :bangbang:
- [ ] Run Prettier and Eslint `npm run format && npm run lint`
- [ ] PR title and commit messages are easy for others to follow :doughnut:
- [ ] Include a screenshot if it's for a view :camera:
